### PR TITLE
Add option to show check icon on the left side

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,34 +91,35 @@ import {GestureHandlerRootView} from 'react-native-gesture-handler';
 ## Properties
 
 #### Basic
-| Prop               |    Default    |    Type    | Description                                                                                                 |
-| :----------------- | :-----------: | :--------: | :---------------------------------------------------------------------------------------------------------- |
-| title              |       ''      |  `string`  | Title on top of the picker box                                                                              |
-| placeholder        |       ''      |  `string`  | Placeholder inside the picker box                                                                           |
-| bottomSheetTitle   |       ''      |  `string`  | Title on the bottom sheet                                                                                   |
-| required           |     false     |  `boolean` | If true, show the * sign on the title                                                                       |
-| requiredColor      |   '#d50000'   |  `string`  | The color of the * sign                                                                                     |
-| primaryColor       |    'black'    |  `string`  | Color for the pressable component                                                                           |
-| secondaryColor     |   '#b5b5b5'   |  `string`  | Color of the audio button while the audio is playing                                                        |
-| items              |       []      |  `Array`   | Array of item for selections.(Ex: [{label: 'example', value: 1}])                                           |
-| selectedItem       |     null      |            | The selected value                                                                                          |
-| snapPoints         |    ['60%']    |  `Array`   | The height of the bottom sheet                                                                              |
-| pickerContentHeight|      425      |  `number`  | The height of the content inside the bottom sheet                                                           |
-| pickerUuid         |      ''       |  `string`  | The uuid of the picker (for play audio purpose)                                                             |
-| placeholderAudio   |     null      |  `audio`   | The audio of the placeholder (support .mp3). If null, it will not show play audio botton on the picker box  |
-| playingUuid        |      ''       |  `string`  | The uuid of the playing auido component (to prevent playing audio overlap each other)                       |
-| hideListItemAudio  |     false     |  `boolean` | Hide or show the play audio button on the list item                                                         |
-| showCheckIcon      |     false     |  `boolean` | Hide or show the check icon on the selected item                                                            |
-| checkIconSize      |      24       |  `number`  | Size of the check icon                                                                                      |
-| isOutlined         |     false     |  `boolean` | If set to `true`, the picker will render in outlined style                                                  |
-| pickerFontSize     |      16       |  `number`  | Font size of the label inside the picker box                                                                |
-| indicatorLabel     |      ''       |  `string`  | The label on the right side of the picker box                                                               |
-| disabled           |     false     |  `boolean` | The status to disable the picker                                                                            |
-| disabledColor      |   '#cdccc'    |  `string`  | The color of the picker when disabled                                                                       |
-| titleFontFamily    |      ''       |  `string`  | The font family of the title in the bottom sheet                                                            |
-| itemFontFamily     |      ''       |  `string`  | The font family of the item in the bottom sheet                                                             |
-| selectedFieldName  |     null      |  `string`  | The custom field name used to get the selected value of the item (default field name is `value`)            |
-| showRadioStyle     |     false     |  `boolean` | If true, show the radio button style (circle & check icon) on the right side of each list                   |
+| Prop               |    Default    |    Type    | Description                                                                                                                                   |
+| :----------------- | :-----------: | :--------: | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| title              |       ''      |  `string`  | Title on top of the picker box                                                                                                                |
+| placeholder        |       ''      |  `string`  | Placeholder inside the picker box                                                                                                             |
+| bottomSheetTitle   |       ''      |  `string`  | Title on the bottom sheet                                                                                                                     |
+| required           |     false     |  `boolean` | If true, show the * sign on the title                                                                                                         |
+| requiredColor      |   '#d50000'   |  `string`  | The color of the * sign                                                                                                                       |
+| primaryColor       |    'black'    |  `string`  | Color for the pressable component                                                                                                             |
+| secondaryColor     |   '#b5b5b5'   |  `string`  | Color of the audio button while the audio is playing                                                                                          |
+| items              |       []      |  `Array`   | Array of item for selections.(Ex: [{label: 'example', value: 1}])                                                                             |
+| selectedItem       |     null      |            | The selected value                                                                                                                            |
+| snapPoints         |    ['60%']    |  `Array`   | The height of the bottom sheet                                                                                                                |
+| pickerContentHeight|      425      |  `number`  | The height of the content inside the bottom sheet                                                                                             |
+| pickerUuid         |      ''       |  `string`  | The uuid of the picker (for play audio purpose)                                                                                               |
+| placeholderAudio   |     null      |  `audio`   | The audio of the placeholder (support .mp3). If null, it will not show play audio botton on the picker box                                    |
+| playingUuid        |      ''       |  `string`  | The uuid of the playing auido component (to prevent playing audio overlap each other)                                                         |
+| hideListItemAudio  |     false     |  `boolean` | Hide or show the play audio button on the list item                                                                                           |
+| showCheckIcon      |     false     |  `boolean` | Hide or show the check icon on the selected item                                                                                              |
+| checkIconSize      |      24       |  `number`  | Size of the check icon                                                                                                                        |
+| isOutlined         |     false     |  `boolean` | If set to `true`, the picker will render in outlined style                                                                                    |
+| pickerFontSize     |      16       |  `number`  | Font size of the label inside the picker box                                                                                                  |
+| indicatorLabel     |      ''       |  `string`  | The label on the right side of the picker box                                                                                                 |
+| disabled           |     false     |  `boolean` | The status to disable the picker                                                                                                              |
+| disabledColor      |   '#cdccc'    |  `string`  | The color of the picker when disabled                                                                                                         |
+| titleFontFamily    |      ''       |  `string`  | The font family of the title in the bottom sheet                                                                                              |
+| itemFontFamily     |      ''       |  `string`  | The font family of the item in the bottom sheet                                                                                               |
+| selectedFieldName  |     null      |  `string`  | The custom field name used to get the selected value of the item (default field name is `value`)                                              |
+| showRadioStyle     |     false     |  `boolean` | If `true`, show the radio button style (circle & round icon) on the right side of each list                                                   |
+| showLeftCheckIcon  |     false     |  `boolean` | If `true` with showRadioStyle and showCheckIcon are `false`, show the radio button style (circle & check icon) on the left side of each list  |
 
 #### Custom styles
 

--- a/src/components/BottomSheetPickerComponent.js
+++ b/src/components/BottomSheetPickerComponent.js
@@ -43,6 +43,7 @@ const BottomSheetPickerComponent = (props) => {
                         itemFontFamily={props.itemFontFamily}
                         selectedFieldName={props.selectedFieldName}
                         showRadioStyle={props.showRadioStyle}
+                        showLeftCheckIcon={props.showLeftCheckIcon}
                       />
 
     pickerRef.current?.setBodyContent(content);

--- a/src/components/BottomSheetPickerListComponent.js
+++ b/src/components/BottomSheetPickerListComponent.js
@@ -51,6 +51,7 @@ const BottomSheetPickerListComponent = (props) => {
             itemFontFamily={props.itemFontFamily}
             selectedFieldName={props.selectedFieldName}
             showRadioStyle={props.showRadioStyle}
+            showLeftCheckIcon={props.showLeftCheckIcon}
           />
         </Pressable>
       </ScrollView>

--- a/src/components/BottomSheetPickerListItemComponent.js
+++ b/src/components/BottomSheetPickerListItemComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import Icon from 'react-native-vector-icons/Feather';
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome5';
 import {LIST_ITEM_FONT_SIZE} from '../constants/font_size_constant';
 import PlayAudioComponent from './playAudios/PlayAudioComponent';
 import pickerHelper from '../helpers/picker_helper';
@@ -27,9 +28,16 @@ const BottomSheetPickerListItemComponent = (props) => {
     if (props.showCheckIcon && props.selectedItem == pickerHelper.getSelectedValue(props.selectedFieldName, item))
       return <Icon name='check' size={props.checkIconSize || 24} color={props.secondaryColor} style={{marginLeft: !props.hideListItemAudio ? 24 : 0}}/>
     else if (props.showRadioStyle)
-      return <View style={styles.radioButton}>
+      return <View style={styles.roundContainer}>
               {props.selectedItem == pickerHelper.getSelectedValue(props.selectedFieldName, item) && <View style={{width: 14, height: 14, borderRadius: 14, backgroundColor: props.primaryColor}} />}
             </View>
+  }
+
+  const renderLeftCheckIcon = (item) => {
+    const containerStyle = {backgroundColor: props.primaryColor, borderColor: props.primaryColor};
+    return <View style={[styles.roundContainer, {marginRight: 10, height: 22, width: 22}, item.value == props.selectedItem && containerStyle]}>
+              <FontAwesomeIcon name='check' size={13} color='white'/>
+           </View>
   }
 
   const renderListItem = () => {
@@ -43,6 +51,7 @@ const BottomSheetPickerListItemComponent = (props) => {
             { props.customListItem ? props.customListItem(item)
               :
               <View style={{flex: 1, flexDirection: 'row'}}>
+                { (props.showLeftCheckIcon && !props.showCheckIcon && !props.showRadioStyle) && renderLeftCheckIcon(item)}
                 <Text style={[{ color: itemColor(item, 'black'), fontSize: LIST_ITEM_FONT_SIZE }, props.itemFontFamily && {fontFamily: props.itemFontFamily}, props.itemTextStyle]}>{ item.label }</Text>
               </View>
             }
@@ -63,7 +72,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     height: 56,
   },
-  radioButton: {
+  roundContainer: {
+    alignItems: 'center',
     alignItems: 'center',
     borderColor: '#D3D3D3',
     borderRadius: 20,


### PR DESCRIPTION
This pull request adds the option to show the check icon (similar to the radio button style) on the left side of the list item in the bottom sheet.